### PR TITLE
feat: add missings security headers and clarify noreferrer

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -19,12 +19,12 @@ Ask a team developer for values
 
 #### Database
 
-You need a postgresql database setup for usint the app in dev environment.
+You need a postgresql database setup for using the app in dev environment.
 When setup, add the database connection string in `.env`
 
 Database client is Prisma https://www.prisma.io/
 
-Run `pnpm -F web prisma:generate` to geneate the prisma client, then `pnpm -F web prisma migrate deploy` to setup your schema.
+Run `pnpm -F web prisma:generate` to generate the prisma client, then `pnpm -F web prisma migrate deploy` to setup your schema.
 
 To seed your database with fixtures, run `pnpm -F cli fixtures:load`
 

--- a/apps/web/src/app/(private)/beneficiaires/[fileNumber]/DocumentViewer.tsx
+++ b/apps/web/src/app/(private)/beneficiaires/[fileNumber]/DocumentViewer.tsx
@@ -28,6 +28,7 @@ export function DocumentViewer({
   // TODO button to download asset and button to Open asset in new tab
   return (
     <div>
+      {/* FIXME: Is noreferrer required */}
       <a href={viewUrl.data.url} target="_blank" rel="noreferrer">
         {name}
       </a>

--- a/apps/web/src/app/(private)/mon-compte/page.tsx
+++ b/apps/web/src/app/(private)/mon-compte/page.tsx
@@ -32,7 +32,6 @@ const MonComptePage = async () => {
               {/*  className="fr-link" */}
               {/*  href={getInclusionConnectProfilePageUrl()} */}
               {/*  target="_blank" */}
-              {/*  rel="noreferrer" */}
               {/*  style={{ margin: '0 auto 0 0' }} */}
               {/* > */}
               {/*  Voir mon profil Inclusion Connect */}
@@ -42,7 +41,6 @@ const MonComptePage = async () => {
                 className="fr-link"
                 href={getInclusionConnectChangePasswordUrl()}
                 target="_blank"
-                rel="noreferrer"
                 style={{ margin: '0 auto 0 0' }}
               >
                 Changer mon mot de passe
@@ -56,7 +54,6 @@ const MonComptePage = async () => {
                 className="fr-btn"
                 href={getInclusionConnectLogoutUrl()}
                 target="_blank"
-                rel="noreferrer"
               >
                 Se déconnecter d&apos;Inclusion Connect
               </Link>

--- a/apps/web/src/app/(public)/PublicFooter.tsx
+++ b/apps/web/src/app/(public)/PublicFooter.tsx
@@ -31,7 +31,6 @@ function PublicFooter() {
                   href="https://gouvernement.fr"
                   className="fr-footer__content-link"
                   target="_blank"
-                  rel="noreferrer"
                 >
                   gouvernement.fr
                 </a>
@@ -41,7 +40,6 @@ function PublicFooter() {
                   href="https://service-public.fr"
                   className="fr-footer__content-link"
                   target="_blank"
-                  rel="noreferrer"
                 >
                   service-public.fr
                 </a>
@@ -51,7 +49,6 @@ function PublicFooter() {
                   href="https://data.gouv.fr"
                   className="fr-footer__content-link"
                   target="_blank"
-                  rel="noreferrer"
                 >
                   data.gouv.fr
                 </a>
@@ -61,7 +58,6 @@ function PublicFooter() {
                   href="https://beta.gouv.fr"
                   className="fr-footer__content-link"
                   target="_blank"
-                  rel="noreferrer"
                 >
                   beta.gouv.fr
                 </a>

--- a/apps/web/src/app/(public)/confidentialite/page.tsx
+++ b/apps/web/src/app/(public)/confidentialite/page.tsx
@@ -344,7 +344,6 @@ function ConfidentialityPage() {
               <a
                 href="https://www.cnil.fr/fr/cookies-traceurs-que-dit-la-loi"
                 target="_blank"
-                rel="noreferrer"
               >
                 Cookies &amp; traceurs : que dit la loi ?
                 <span className="fr-sr-only">Ouvre une nouvelle fenêtre</span>
@@ -354,7 +353,6 @@ function ConfidentialityPage() {
               <a
                 href="https://www.cnil.fr/fr/cookies-les-outils-pour-les-maitriser"
                 target="_blank"
-                rel="noreferrer"
               >
                 Cookies : les outils pour les maîtriser
                 <span className="fr-sr-only">Ouvre une nouvelle fenêtre</span>
@@ -367,11 +365,7 @@ function ConfidentialityPage() {
           <p>
             Bien sûr ! Les statistiques d’usage de la majorité de nos produits
             sont disponibles en accès libre sur&nbsp;
-            <a
-              href="https://stats.data.gouv.fr/"
-              target="_blank"
-              rel="noreferrer"
-            >
+            <a href="https://stats.data.gouv.fr/" target="_blank">
               stats.data.gouv.fr
               <span className="fr-sr-only">Ouvre une nouvelle fenêtre</span>
             </a>
@@ -450,7 +444,7 @@ function ConfidentialityPage() {
             pas respectés ou que le traitement n’est pas conforme à la
             réglementation sur la protection des données à caractère personnel,
             vous pouvez adresser une réclamation à{' '}
-            <a href="https://www.cnil.fr" target="_blank" rel="noreferrer">
+            <a href="https://www.cnil.fr" target="_blank">
               la CNIL
               <span className="fr-sr-only">Ouvre une nouvelle fenêtre</span>
             </a>

--- a/apps/web/src/app/EnvironmentInformation.tsx
+++ b/apps/web/src/app/EnvironmentInformation.tsx
@@ -2,7 +2,7 @@ import { PrivateConfig, PublicConfig } from '@mss/web/config'
 
 export function EnvironmentInformation() {
   const branch = PrivateConfig.Branch
-  const {isMain} = PrivateConfig
+  const { isMain } = PrivateConfig
 
   // Branch can be empty on dev env
   if (isMain || !branch) {
@@ -45,7 +45,7 @@ export function EnvironmentInformation() {
               {branch}&#34; sur Storybook
             </a>
             <br className="fr-hidden-lg fr-mt-2v" />
-            <a href={PublicConfig.mainLiveUrl} rel="noreferrer" target="_blank">
+            <a href={PublicConfig.mainLiveUrl} target="_blank">
               <span className="fr-icon--sm fr-icon-france-line" /> Version
               officielle
             </a>

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -6,6 +6,7 @@ const middleware: NextMiddleware = (request) => {
   const requestHost = request.headers.get('host')
   const baseUrl = process.env.BASE_URL
 
+  // FIXME: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Strict-Transport-Security states "Note: This is more secure than simply configuring a HTTP to HTTPS (301) redirect on your server, where the initial HTTP connection is still vulnerable to a man-in-the-middle attack.". But they keep applying this redirect in recommended SSL configs: https://ssl-config.mozilla.org/
   if (
     nodeEnvironment === 'production' &&
     // We redirect if protocol is not secure https

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -34,6 +34,10 @@ const middleware: NextMiddleware = (request) => {
   response.headers.append('X-Content-Type-Options', 'nosniff')
   response.headers.append('X-XSS-Protection', '1; mode=block')
   response.headers.delete('X-Powered-By')
+  response.headers.append(
+    'Strict-Transport-Security',
+    'max-age=63072000 always',
+  )
 
   // TODO This CSP policy is too restrictive an account has been created in report-uri.com. Make this in another deployment.
   // TODO use https://www.npmjs.com/package/csp-header


### PR DESCRIPTION
- [X] J'ai rajouté l'en-tête `Strict-Transport-Policy` pour le HSTS
- [X] Suite à la discussion sur Mattermost, ce qu'il en est ressorti c'est que : 
  - C'est peut-être pas nécessaire de systématiquement ajouter l'en-tête `Referer-Policy`
  - Le `rel` `noopener`n'est pas utile
  - Le `rel` `noreferrer` est utile si on ne veut pas de suivi de nos utilisateurs. Donc je l'ai retiré de tous les liens externes qui pointent chez les copains (IC, *.gouv.fr, cnil.fr, etc.). Tout ce qui est GitHub, GitBook, Notion reste en `noreferrer`
- [ ] Il reste à faire les CSP, je creuse jeudi