### PR TITLE
fix: side menu links for agent role

### DIFF
--- a/apps/web/src/app/(private)/statistiques/page.tsx
+++ b/apps/web/src/app/(private)/statistiques/page.tsx
@@ -8,8 +8,8 @@ import { FamilySituationChart } from '@mss/web/app/(private)/statistiques/Family
 import { AgeChart } from '@mss/web/app/(private)/statistiques/AgeChart'
 import { ChartJs } from '@mss/web/app/(private)/statistiques/ChartJs'
 import { Routes } from '@mss/web/app/routing/routes'
-import notFound from './not-found'
 import { canAccessStatsPage } from '@mss/web/security/rules'
+import { notFound } from 'next/navigation'
 
 const StatistiquesPage = async () => {
   const user = await getAuthenticatedAgent()

--- a/apps/web/src/app/(private)/statistiques/page.tsx
+++ b/apps/web/src/app/(private)/statistiques/page.tsx
@@ -8,15 +8,23 @@ import { FamilySituationChart } from '@mss/web/app/(private)/statistiques/Family
 import { AgeChart } from '@mss/web/app/(private)/statistiques/AgeChart'
 import { ChartJs } from '@mss/web/app/(private)/statistiques/ChartJs'
 import { Routes } from '@mss/web/app/routing/routes'
+import notFound from './not-found'
+import { canAccessStatsPage } from '@mss/web/security/rules'
 
 const StatistiquesPage = async () => {
-  const { structureId } = await getAuthenticatedAgent()
+  const user = await getAuthenticatedAgent()
+
+  if (!canAccessStatsPage(user)) {
+    notFound()
+    return null
+  }
+
   const [genderStats, familySituationStats, ageStats, supportStats] =
     await Promise.all([
-      StatisticsQuery.getGenderStats(structureId),
-      StatisticsQuery.getFamilyStats(structureId),
-      StatisticsQuery.getAgeStats(structureId),
-      StatisticsQuery.getSupportStats(structureId),
+      StatisticsQuery.getGenderStats(user.structureId),
+      StatisticsQuery.getFamilyStats(user.structureId),
+      StatisticsQuery.getAgeStats(user.structureId),
+      StatisticsQuery.getSupportStats(user.structureId),
     ])
 
   return (

--- a/apps/web/src/components/SideMenuLinks/SideMenuLinks.tsx
+++ b/apps/web/src/components/SideMenuLinks/SideMenuLinks.tsx
@@ -71,7 +71,6 @@ function SideMenuLinks({
     })
   }
 
-  // TODO MSS if admin or structure boss??
   if (canListUsers(user, { structureId: user.structureId }))
     menuLinks.push(Routes.Utilisateurs.Index)
 

--- a/apps/web/src/components/SideMenuLinks/SideMenuLinks.tsx
+++ b/apps/web/src/components/SideMenuLinks/SideMenuLinks.tsx
@@ -5,16 +5,13 @@ import { SessionUser } from '@mss/web/auth/sessionUser'
 import { useIsCurrentPathname } from '@mss/web/hooks/useIsCurrentPathname'
 import { Routes } from '@mss/web/app/routing/routes'
 import { deserialize, Serialized } from '@mss/web/utils/serialization'
-import { canListStructures } from '@mss/web/security/rules'
+import {
+  canAccessStatsPage,
+  canListStructures,
+  canListUsers,
+} from '@mss/web/security/rules'
 
 type MenuLink = { title: string; path: string; icon: string }
-const mainLinks: MenuLink[] = [
-  Routes.Index,
-  Routes.Beneficiaires.Index,
-  Routes.Accompagnements.Index,
-  Routes.Statistiques.Index,
-  Routes.MonCompte.Index,
-]
 
 function MenuLinkItem({
   item: { current, icon, path, title },
@@ -53,33 +50,35 @@ function SideMenuLinks({
   const isCurrent = useIsCurrentPathname()
 
   // TODO MSS depends on role
-  const userSpecificLinks: MenuLink[] = []
+  const menuLinks: MenuLink[] = [
+    Routes.Index,
+    Routes.Beneficiaires.Index,
+    Routes.Accompagnements.Index,
+  ]
 
-  if (canListStructures(user)) {
-    userSpecificLinks.push({
-      title: 'Structures',
-      path: Routes.Structures.Index.path,
-      icon: 'building-line',
-    })
-  } else if (user.structureId) {
-    userSpecificLinks.push({
+  if (canAccessStatsPage(user)) menuLinks.push(Routes.Statistiques.Index)
+
+  menuLinks.push(Routes.MonCompte.Index)
+
+  if (canListStructures(user)) menuLinks.push(Routes.Structures.Index)
+  else if (user.structureId) {
+    menuLinks.push({
+      ...Routes.Structure.Index,
       title: 'Structure',
       path: Routes.Structure.Index.path({
         id: user.structureId,
       }),
-      icon: 'building-line',
     })
   }
 
   // TODO MSS if admin or structure boss??
-  userSpecificLinks.push(Routes.Utilisateurs.Index)
+  if (canListUsers(user, { structureId: user.structureId }))
+    menuLinks.push(Routes.Utilisateurs.Index)
 
-  const menuLinksWithCurrent = [...mainLinks, ...userSpecificLinks].map(
-    (link) => ({
-      ...link,
-      current: isCurrent(link.path, link.path === Routes.Index.path),
-    }),
-  )
+  const menuLinksWithCurrent = menuLinks.map((link) => ({
+    ...link,
+    current: isCurrent(link.path, link.path === Routes.Index.path),
+  }))
 
   return (
     <ul className="fr-sidemenu__list">


### PR DESCRIPTION
@hugues-m ça touche aux rôles et permissions donc je veux bien ton avis.

Aussi, quand j'accède directement à `/statistiques`, maintenant que j'ai mis la redirection vers _not found_ si on n'a pas accès (c'est correctement fait ?), j'ai cette erreur qui sort :

```
Uncaught Error: Cannot access NotFoundError.apply on the server. You cannot dot into a client module from a server component. You can only pass the imported name through.

The above error occurred in the <RedirectErrorBoundary> component:
```

Assez mystique pour moi, du coup j'atterris sur une 500 plutôt qu'une 400