### PR TITLE
fix: sorting descending

### DIFF
--- a/apps/web/src/app/(private)/accompagnements/(liste)/page.tsx
+++ b/apps/web/src/app/(private)/accompagnements/(liste)/page.tsx
@@ -37,7 +37,7 @@ const AccompagnementsListPage = async ({
 
   const currentSorting: Sorting = {
     by: searchParams?.tri ?? '',
-    direction: searchParams?.ordre ?? 'asc',
+    direction: searchParams?.ordre ?? 'desc',
   }
 
   const [helpRequestsListResult, followupsListResult] = await Promise.all([

--- a/apps/web/src/components/Generic/sorting.ts
+++ b/apps/web/src/components/Generic/sorting.ts
@@ -19,6 +19,9 @@ export const createSortLinkHelper =
     parametersToLink({
       page: pageNumber === 1 ? undefined : pageNumber?.toString(),
       tri: sorting.by === defaultSorting?.by ? undefined : sorting.by,
-      ordre: sorting.direction,
+      ordre:
+        sorting.direction === defaultSorting?.direction
+          ? undefined
+          : sorting.direction,
       ...otherParameters,
     })

--- a/apps/web/src/components/Generic/sorting.ts
+++ b/apps/web/src/components/Generic/sorting.ts
@@ -19,9 +19,6 @@ export const createSortLinkHelper =
     parametersToLink({
       page: pageNumber === 1 ? undefined : pageNumber?.toString(),
       tri: sorting.by === defaultSorting?.by ? undefined : sorting.by,
-      ordre:
-        sorting.direction === defaultSorting?.direction
-          ? undefined
-          : sorting.direction,
+      ordre: sorting.direction,
       ...otherParameters,
     })


### PR DESCRIPTION
Tout petit correctif, mais ça m'intéresse de savoir ce que tu (@hugues-m) en penses ?

Le problème arrivait lorsqu'on cliquait une seconde fois sur le lien de tri. Lorsque le _query param_ de l'ordre du tri était retiré de l'URL pour basculer sur descendant, le tri par défaut considéré était ascendant donc ça rentrait en conflit.

Je vois pas mal de TODO sur cette partie. C'est en chantier ?

Est-ce que ce serait une bonne idée d'uniformiser la présence/non-présence du _query param_ de l'ordre au sein de l'application ? Parce que par exemple pour les bénéficiaires c'est l'inverse (absence = ascendant ou `order=desc`) ?